### PR TITLE
[GEN] 🤖 Automated Google Calendar Scheduling via GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/google-meet.yml
+++ b/.github/ISSUE_TEMPLATE/google-meet.yml
@@ -1,0 +1,48 @@
+name: "Meeting Name"
+description: "Buat jadwal meeting atau workshop baru"
+labels: ["meeting", "workshop"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Formulir ini akan membuat file ICS secara otomatis.
+  - type: input
+    id: title
+    attributes:
+      label: "Judul Materi"
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: "Deskripsi"
+      required: true
+  - type: input
+    id: date
+    attributes:
+      label: "Tanggal"
+      placeholder: "DD-MM-YYYY"
+      description: "Format: DD-MM-YYYY (Contoh: 25-12-2023)"
+    validations:
+      required: true
+  - type: dropdown
+    id: time
+    attributes:
+      label: "Jam Mulai (WIB)"
+      options:
+        - "19:00"
+        - "19:30"
+        - "20:00"
+        - "20:30"
+        - "21:00"
+    validations:
+      required: true
+  - type: dropdown
+    id: duration
+    attributes:
+      label: "Durasi"
+      options:
+        - "1 Jam"
+        - "1.5 Jam"
+        - "2 Jam"
+    validations:
+      required: true

--- a/.github/workflows/tools/generate-ics.yml
+++ b/.github/workflows/tools/generate-ics.yml
@@ -1,0 +1,108 @@
+name: Generate ICS Links
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  generate-links:
+    runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'meeting') || contains(github.event.issue.labels.*.name, 'workshop')
+    steps:
+      - name: Generate Calendar Links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body;
+            
+            // Helper function to extract values using regex
+            function extractValue(regex) {
+              const match = body.match(regex);
+              return match ? match[1].trim() : null;
+            }
+
+            const title = extractValue(/### Judul Materi\s*\n\s*(.*)/);
+            const description = extractValue(/### Deskripsi\s*\n\s*([\s\S]*?)(?=\n###|$)/) || "";
+            const dateStr = extractValue(/### Tanggal\s*\n\s*(.*)/);
+            const timeStr = extractValue(/### Jam Mulai \(WIB\)\s*\n\s*(.*)/);
+            const durationStr = extractValue(/### Durasi\s*\n\s*(.*)/);
+
+            if (!title || !dateStr || !timeStr || !durationStr) {
+              console.log("Required fields missing in issue body.");
+              return;
+            }
+
+            // Parse Date (DD-MM-YYYY)
+            const dateParts = dateStr.split('-');
+            if (dateParts.length !== 3) {
+              console.log("Invalid date format.");
+              return;
+            }
+            const day = parseInt(dateParts[0], 10);
+            const month = parseInt(dateParts[1], 10) - 1; // 0-indexed
+            const year = parseInt(dateParts[2], 10);
+
+            // Parse Time (HH:mm)
+            const timeParts = timeStr.split(':');
+            const hour = parseInt(timeParts[0], 10);
+            const minute = parseInt(timeParts[1], 10);
+
+            // Convert WIB (UTC+7) to UTC
+            // We construct the date in UTC by subtracting 7 hours from the WIB time
+            const startTimestamp = Date.UTC(year, month, day, hour - 7, minute);
+            const startDate = new Date(startTimestamp);
+
+            // Calculate Duration
+            let durationMinutes = 60;
+            if (durationStr.includes("1.5")) durationMinutes = 90;
+            if (durationStr.includes("2")) durationMinutes = 120;
+
+            const endTimestamp = startTimestamp + (durationMinutes * 60 * 1000);
+            const endDate = new Date(endTimestamp);
+
+            // Format for Google Calendar (YYYYMMDDThhmmssZ)
+            function formatGoogleDate(date) {
+              return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+            }
+
+            const startISO = formatGoogleDate(startDate);
+            const endISO = formatGoogleDate(endDate);
+            const location = "https://meet.google.com/hqb-fymu-dgu";
+
+            // Generate Google Calendar Link
+            const googleUrl = new URL("https://calendar.google.com/calendar/render");
+            googleUrl.searchParams.append("action", "TEMPLATE");
+            googleUrl.searchParams.append("text", title);
+            googleUrl.searchParams.append("details", description);
+            googleUrl.searchParams.append("location", location);
+            googleUrl.searchParams.append("dates", `${startISO}/${endISO}`);
+
+            // Generate Agical.io Link
+            // Using standard params: subject, description, location, dtstart, dtend
+            const agicalUrl = new URL("https://agical.io/");
+            agicalUrl.searchParams.append("format", "ics");
+            agicalUrl.searchParams.append("subject", title);
+            agicalUrl.searchParams.append("description", description);
+            agicalUrl.searchParams.append("location", location);
+            agicalUrl.searchParams.append("dtstart", startDate.toISOString());
+            agicalUrl.searchParams.append("dtend", endDate.toISOString());
+
+            const commentBody = `### 📅 Calendar Links Generated
+
+            | Service | Link |
+            | :--- | :--- |
+            | **Google Calendar** | [Add to Google Calendar](${googleUrl.toString()}) |
+            | **ICS File** | [Download .ics](${agicalUrl.toString()}) |
+
+            **Event Details:**
+            - **Topic:** ${title}
+            - **Time:** ${dateStr} at ${timeStr} WIB
+            - **Location:** ${location}
+            `;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: commentBody
+            });


### PR DESCRIPTION
This PR adds automation to create calendar events directly from GitHub Issues, making it easy to schedule meetings and workshops for the BlankOn community.

### What's New

#### 1. **Issue Template for Meeting Scheduling** (`.github/ISSUE_TEMPLATE/google-meet.yml`)
- Indonesian-language form template
- Fields for meeting details:
  - **Judul Materi**: Topic/title of the meeting
  - **Deskripsi**: Description
  - **Tanggal**: Date in DD-MM-YYYY format
  - **Jam Mulai (WIB)**: Start time with predefined options (19:00 - 21:00)
  - **Durasi**: Duration options (1, 1.5, or 2 hours)
- Automatically applies `meeting` and `workshop` labels

#### 2. **Automated Workflow** (`.github/workflows/tools/generate-ics.yml`)
- Triggers on issue creation/editing with `meeting` or `workshop` labels
- Parses issue body and extracts meeting details
- Converts WIB (UTC+7) timezone to UTC
- Generates two calendar integration options:
  - **Google Calendar** link (one-click add to calendar)
  - **ICS file** download link via Agical.io
- Posts formatted comment with calendar links and event summary

### Benefits
- ✅ Streamlined meeting scheduling process
- ✅ No manual calendar link generation needed
- ✅ Consistent meeting location (Google Meet)
- ✅ Easy calendar integration for all participants
- ✅ Indonesian language support for better accessibility

### Usage
1. Create a new issue using the "Meeting Name" template
2. Fill in the meeting details
3. Submit the issue
4. Bot automatically comments with calendar links
5. Participants can add the event to their calendars with one click